### PR TITLE
design: 프로젝트 라벨 편집 ui 제거

### DIFF
--- a/cvat-ui/src/components/project-page/details.tsx
+++ b/cvat-ui/src/components/project-page/details.tsx
@@ -4,12 +4,14 @@
 // SPDX-License-Identifier: MIT
 
 import React, { useState } from 'react';
+import { useSelector } from 'react-redux';
 import dayjs from 'dayjs';
 import { Row, Col } from 'antd/lib/grid';
 import Title from 'antd/lib/typography/Title';
 import Text from 'antd/lib/typography/Text';
 
 import { getCore, Project } from 'cvat-core-wrapper';
+import { CombinedState } from 'reducers';
 import LabelsEditor from 'components/labels-editor/labels-editor';
 import BugTrackerEditor from 'components/task-page/bug-tracker-editor';
 import UserSelector from 'components/task-page/user-selector';
@@ -25,6 +27,7 @@ interface DetailsComponentProps {
 export default function DetailsComponent(props: DetailsComponentProps): JSX.Element {
     const { project, onUpdateProject } = props;
     const [projectName, setProjectName] = useState(project.name);
+    const isSuperuser = useSelector((state: CombinedState) => state.auth.user?.isSuperuser ?? false);
 
     return (
         <div data-cvat-project-id={project.id} className='cvat-project-details'>
@@ -72,13 +75,15 @@ export default function DetailsComponent(props: DetailsComponentProps): JSX.Elem
                     />
                 </Col>
             </Row>
-            <LabelsEditor
-                labels={project.labels.map((label: any): string => label.toJSON())}
-                onSubmit={(labels: any[]): void => {
-                    project.labels = labels.map((labelData): any => new core.classes.Label(labelData));
-                    onUpdateProject(project);
-                }}
-            />
+            {isSuperuser && (
+                <LabelsEditor
+                    labels={project.labels.map((label: any): string => label.toJSON())}
+                    onSubmit={(labels: any[]): void => {
+                        project.labels = labels.map((labelData): any => new core.classes.Label(labelData));
+                        onUpdateProject(project);
+                    }}
+                />
+            )}
         </div>
     );
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #9 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
조직 역할에 있는 worker, supervisor, maintainer, owner 는 프로젝트 상세페이지에서 라벨을 수정할 수 없도록 ui를 제거했습니다.
django의 superuser의 경우에만 라벨 편집 ui가 보이도록 해 수정 가능하도록 했습니다.

### 스크린샷 (선택)
(before)
<img width="2211" height="274" alt="image" src="https://github.com/user-attachments/assets/9bb96899-3bb5-4c68-a8f3-ab5f04068245" />

(after)
- 일반 사용자
<img width="1912" height="913" alt="image" src="https://github.com/user-attachments/assets/515269ce-39ea-46a7-9398-8cb516d04a0b" />

- superuser
<img width="1913" height="905" alt="image" src="https://github.com/user-attachments/assets/5e067f2e-9d87-4227-a27e-bf440ac50b83" />


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> Redux 스토어에 로그인 시점에 서버로부터 받아온 현재 사용자 정보(state.auth.user)가 저장되어 있고, 해당 객체에 Django의 is_superuser 값이 isSuperuser 필드로 포함되어 있습니다.
project-page/details.tsx에서 useSelector로 isSuperuser 값을 읽어, true일 때만 <LabelsEditor> 컴포넌트를 렌더링하도록 변경했습니다.
